### PR TITLE
fix: lerna publish access flag

### DIFF
--- a/.github/workflows/packages-deployment.yaml
+++ b/.github/workflows/packages-deployment.yaml
@@ -38,4 +38,4 @@ jobs:
         run: yarn lerna run build
 
       - name: Publish package
-        run: 'yarn lerna publish from-package --yes'
+        run: 'yarn lerna publish from-package --yes --no-verify-access'


### PR DESCRIPTION
npm automatition tokens not working on CI/CD.
related to [this issue](https://github.com/lerna/lerna/issues/2788)