### PR TITLE
build: fix npm_token missing

### DIFF
--- a/.github/workflows/packages-deployment.yaml
+++ b/.github/workflows/packages-deployment.yaml
@@ -7,6 +7,9 @@ on:
 jobs:
   cd:
     runs-on: ubuntu-latest
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
     steps:
 
       - uses: actions/checkout@v2
@@ -17,11 +20,13 @@ jobs:
       - name: Configure CI Git User
         run: |
           git config --global user.email "frontend@securityscorecard.io"
-          git config --global user.name "$GITHUB_ACTOR"
+          git config --global user.name "frontend"
 
-      - uses: actions/setup-node@v2
+      - name: Setup .npmrc file for publish
+        uses: actions/setup-node@v2
         with:
           node-version: '14.17.4'
+          registry-url: 'https://registry.npmjs.org'
 
       - uses: actions/cache@v2
         with:
@@ -38,4 +43,7 @@ jobs:
         run: yarn lerna run build
 
       - name: Publish package
-        run: 'yarn lerna publish from-package --yes --no-verify-access'
+        run: |
+          yarn logout
+          npm config set '//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}'
+          yarn lerna publish from-package --yes --no-verify-access


### PR DESCRIPTION
`npm_token` wont load on `actions/checkout@v2` due to this issue will temporally
`npm config set '//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}'`
before `lerna publish`