### PR TITLE
feat(sdk): rule trigger and subscriptions owned

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -24,7 +24,25 @@ ssc.apps.updateInstallationData('installation_code', [{'secret_1': 'value'}])
 
 ```js
 // send signals
-ssc.apps.sendSignals('app_name_sapece.signal_type', [{...signal1}, {...signal2}])
+ssc.apps.sendSignals('app_namespace.signal_type', [{...signal1}, {...signal2}])
     .then(signalsResponse => console.log('Signals emmited, check the response for failures', signalsResponse));
 
+```
+
+## Subscriptions Resources
+
+```js
+// send signals
+ssc.subscriptions.owned().then(subscriptions => console.log('List of owned subscriptions', signalsResponse));
+```
+
+## Events Resources
+
+```js
+// send signals
+ssc.events.trigger(({ 
+  ruleId: 'unique_id',
+  type: 'scorecard.changed',
+  event: <EVENT_DETAILS>,
+})).then(({ received }) => console.log('Rule trial', received));
 ```

--- a/packages/sdk/src/__test__/modules/events.spec.ts
+++ b/packages/sdk/src/__test__/modules/events.spec.ts
@@ -1,0 +1,83 @@
+import SecurityScorecardAPI from '../../api';
+import * as nockHelper from '../helpers/nock';
+import Events from '../../modules/events';
+
+beforeEach(() => {
+  nockHelper.stop();
+});
+
+afterEach(() => {
+  nockHelper.stop();
+});
+
+describe('Events', () => {
+  test('dispatch fake event without ruleId', async () => {
+    // helpers
+    const token = 'test_540cb78a-2801-11ec-9621-0242ac130002';
+    const requestBody = {
+      type: 'scorecard.changed',
+      event: { test: 'test_event' },
+    };
+
+    const api = new SecurityScorecardAPI(token, {
+      host: nockHelper.MOCK_SERVER_URL,
+    });
+    const eventsModule = Events(api);
+    const event = eventsModule.trigger(requestBody);
+    await expect(event).rejects.toThrow('A ruleId is required!');
+  });
+  test('dispatch fake event successfully', async () => {
+    // helpers
+    const token = 'test_df5865ab-e168-4231-8438-ed9bee5da14e';
+    const ruleId = 'test_69f7817e-2801-11ec-9621-0242ac130002';
+    const statusReceived = { received: true };
+    const requestBody = {
+      type: 'scorecard.changed',
+      event: { test: 'test_event', trial: { ruleId } },
+    };
+
+    const api = new SecurityScorecardAPI(token, {
+      host: nockHelper.MOCK_SERVER_URL,
+    });
+
+    const scope = nockHelper.listenMockServer({
+      options: { reqheaders: { Authorization: `Token ${token}` } },
+    });
+    // only the event is being sent
+    scope.post('/events/scorecard.changed', requestBody.event).reply(200, statusReceived);
+    const eventsModule = Events(api);
+    const event = await eventsModule.trigger({
+      ruleId,
+      ...requestBody,
+    });
+    expect(event).toMatchObject(statusReceived);
+    expect(scope.isDone()).toEqual(true);
+  });
+  test('dispatch fake event fails', async () => {
+    // helpers
+    const token = 'test_1ea075e2-a783-4650-b324-0f6a13578b4e';
+    const ruleId = 'test_03806000-2806-11ec-9621-0242ac130002';
+    const requestBody = {
+      type: 'scorecard.changed',
+      event: { test: 'test_event', trial: { ruleId } },
+    };
+
+    const api = new SecurityScorecardAPI(token, {
+      host: nockHelper.MOCK_SERVER_URL,
+    });
+
+    const scope = nockHelper.listenMockServer({
+      options: { reqheaders: { Authorization: `Token ${token}` } },
+    });
+    // only the event is being sent
+    scope.post('/events/scorecard.changed', requestBody.event).reply(500, undefined);
+    const eventsModule = Events(api);
+
+    const event = eventsModule.trigger({
+      ruleId,
+      ...requestBody,
+    });
+    await expect(event).rejects.toThrow('there was an error when trying to call [POST] - /events/scorecard.changed');
+    expect(scope.isDone()).toEqual(true);
+  });
+});

--- a/packages/sdk/src/__test__/modules/subscriptions.spec.ts
+++ b/packages/sdk/src/__test__/modules/subscriptions.spec.ts
@@ -1,0 +1,39 @@
+import SecurityScorecardAPI from '../../api';
+import * as nockHelper from '../helpers/nock';
+import Subscriptions from '../../modules/subscriptions';
+
+beforeEach(() => {
+  nockHelper.stop();
+});
+
+afterEach(() => {
+  nockHelper.stop();
+});
+
+describe('Subscriptions', () => {
+  test('list owned subscriptions successfully', async () => {
+    // helpers
+    const token = 'test_540cb78a-2801-11ec-9621-0242ac130002';
+    const userData = { username: 'toretto@securityscorecard.com' };
+
+    const api = new SecurityScorecardAPI(token, {
+      host: nockHelper.MOCK_SERVER_URL,
+    });
+
+    const scope = nockHelper.listenMockServer({
+      options: { reqheaders: { Authorization: `Token ${token}` } },
+    });
+
+    scope.get('/myself').reply(200, userData);
+
+    scope
+      .get('/subscriptions')
+      .query({ username: userData.username, page: 1, 'page-size': 50 })
+      .reply(200, { entries: [], size: 0 });
+
+    const subscriptionsModule = Subscriptions(api);
+    const subscriptions = await subscriptionsModule.owned();
+    expect(subscriptions).toMatchObject({ entries: [], size: 0 });
+    expect(scope.isDone()).toEqual(true);
+  });
+});

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -39,11 +39,16 @@ export function SSC(
   const api = new Api(token, {
     host,
   });
+
   // Initialize modules
   const apps = Modules.Apps(api);
+  const subscriptions = Modules.Subscriptions(api);
+  const events = Modules.Events(api);
 
   return {
     api,
     apps,
+    events,
+    subscriptions,
   };
 }

--- a/packages/sdk/src/modules/events.ts
+++ b/packages/sdk/src/modules/events.ts
@@ -1,0 +1,27 @@
+import { HTTPMethod, SecurityScorecardApi } from '../types';
+import { EventsModule } from './types';
+
+export default function Events(api: SecurityScorecardApi): EventsModule {
+  return {
+    name: 'Events',
+    async trigger(TriggerRequest: {
+      type: string;
+      ruleId?: string;
+      event: any;
+      realEvent?: boolean;
+    }): Promise<{ received: boolean } | undefined> {
+      const rule = TriggerRequest.ruleId;
+      const isReal = TriggerRequest.realEvent;
+      if (!isReal && !rule) throw new Error('A ruleId is required!');
+
+      const { type, event } = TriggerRequest;
+
+      const dispatch = await api.apiCall<{ received: boolean }>(`/events/${type}`, {
+        method: HTTPMethod.POST,
+        body: isReal ? event : { ...event, trial: { ruleId: rule } },
+      });
+
+      return dispatch;
+    },
+  };
+}

--- a/packages/sdk/src/modules/index.ts
+++ b/packages/sdk/src/modules/index.ts
@@ -1,3 +1,5 @@
 import Apps from './apps';
+import Events from './events';
+import Subscriptions from './subscriptions';
 
-export default { Apps };
+export default { Apps, Events, Subscriptions };

--- a/packages/sdk/src/modules/subscriptions.ts
+++ b/packages/sdk/src/modules/subscriptions.ts
@@ -1,0 +1,20 @@
+import { HTTPMethod, SecurityScorecardApi } from '../types';
+import { User, SubscriptionsModule, SubscriptionList } from './types';
+
+export default function Subscriptions(api: SecurityScorecardApi): SubscriptionsModule {
+  return {
+    name: 'Subscriptions',
+    async owned(): Promise<SubscriptionList> {
+      const user = await api.apiCall<User>('/myself', {
+        method: HTTPMethod.GET,
+      });
+
+      const subscriptions = await api.apiCall<SubscriptionList>('/subscriptions', {
+        method: HTTPMethod.GET,
+        query: { username: user!.username, page: 1, 'page-size': 50 },
+      });
+
+      return subscriptions;
+    },
+  };
+}

--- a/packages/sdk/src/modules/types.ts
+++ b/packages/sdk/src/modules/types.ts
@@ -1,3 +1,26 @@
+export type User = {
+  username: string;
+  email?: string;
+  organization?: {
+    domain: string;
+    id: string;
+  };
+  roles?: string[];
+  authMechanism?: string;
+};
+
+export type Subscription = {
+  id: string;
+  pausedAt: string;
+  eventType: string;
+  delivery: { workflow: any };
+  externalEditUrl: string;
+  createdBy: string;
+  createdAt: string;
+  updatedBy: string;
+  updatedAt: string;
+};
+
 type SecurityScorecardModule = {
   name: string;
 };
@@ -22,4 +45,19 @@ export type AppsModule = SecurityScorecardModule & {
     secrets: { key: string; value: string }[];
     // eslint-disable-next-line camelcase
   }): Promise<{ next_url: string }>;
+};
+
+export type SubscriptionList = { entries: Subscription[]; size: number } | undefined;
+
+export type SubscriptionsModule = SecurityScorecardModule & {
+  owned(): Promise<SubscriptionList>;
+};
+
+export type EventsModule = SecurityScorecardModule & {
+  trigger(req: {
+    ruleId?: string;
+    type: string;
+    event: any;
+    realEvent?: boolean;
+  }): Promise<{ received: boolean } | undefined>;
 };

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,4 +1,4 @@
-import { AppsModule } from './modules/types';
+import { AppsModule, EventsModule, SubscriptionsModule } from './modules/types';
 
 export enum HTTPMethod {
   GET = 'get',
@@ -24,4 +24,6 @@ export type SecurityScorecardApi = {
 export type SecurityScorecardSDK = {
   api: SecurityScorecardApi;
   apps: AppsModule;
+  subscriptions: SubscriptionsModule;
+  events: EventsModule;
 };


### PR DESCRIPTION
two new modules:
- events
- subscriptions

two new operations:
- events.trigger (trigger a real or fake event).
- subscriptions.owned (list all the subscriptions owned by `myself`).